### PR TITLE
Reference https://www.mkdocs.org instead of https://mkdocs.org

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ include the full error and traceback.
 
 [Source Code]: https://github.com/waylan/mkdocs-nature
 [Issue Tracker]: https://github.com/waylan/mkdocs-nature/issues
-[MkDocs Documentation]: https://mkdocs.org
+[MkDocs Documentation]: https://www.mkdocs.org
 [Jinja Documentation]: https://jinja.pocoo.org/
 [Sphinx Source]: https://github.com/sphinx-doc/sphinx/tree/master/sphinx/themes
 [Sphinx theme]: http://www.sphinx-doc.org/en/stable/theming.html?highlight=nature#builtin-themes

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,5 +30,5 @@ documented [features](features.md).
     - [Release Notes](release-notes.md)
 
 
-[MkDOcs]: https://mkdocs.org
+[MkDocs]: https://www.mkdocs.org
 [Sphinx theme]: http://www.sphinx-doc.org/en/stable/theming.html?highlight=nature#builtin-themes


### PR DESCRIPTION
Trying to open https://mkdocs.org, the following error is shown:
> mkdocs.org uses an invalid security certificate. The certificate is only valid for the following names: *.github.com, github.com, *.github.io, github.io

(The http protocol works but redirects to the www.mkdocs.org anyway.)