### PR TITLE
Account for code tags in codehilite output

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -154,9 +154,11 @@ Markdown files.
 
 For example, by using the following Markdown:
 
-    ```javascript
-    alert("A JavaScript Alert!");
-    ```
+````text
+```javascript
+alert("A JavaScript Alert!");
+```
+````
 
 Your codeblock will render as:
 

--- a/nature/static/nature.css
+++ b/nature/static/nature.css
@@ -238,6 +238,10 @@ code {
     font-family: monospace;
 }
 
+pre code {
+    background-color: transparent;
+}
+
 .viewcode-back {
     font-family: Arial, sans-serif;
 }


### PR DESCRIPTION
Addresses [Python-Markdon/markdown#936](https://github.com/Python-Markdown/markdown/issues/936).

The change to Python-Markdown is described in the [3.2 release notes](https://python-markdown.github.io/change_log/release-3.2/#codehilite-now-always-wraps-with-ltcodegt-tags)