### PR TITLE
Add support for page specific toc_depth setting

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -86,6 +86,21 @@ copyright: "Copyright &copy; 2017"
 Assign the name to be included with the copyright notice on each page. This
 setting is ignored if `copyright` is not also set.
 
+## MetaData Variables
+
+In addition to the [default metadata variables][meta] supported by MkDocs, the
+McDocs-Nature theme includes support for the following variables defined in a
+page's metadata.
+
+[meta]: https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
+
+### `toc_depth`
+
+Set the depth of the table of contents to a unique value for a specific page.
+Must be an integer. Defaults to `6`. Note that if the configuration option of
+the same name is set for the `toc` Markdown extension, then this option must be
+set to a lower value to have any effect.
+
 ## Search
 
 The MkDocs-Nature theme includes support for MkDocs search plugin. As long as

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 0.5 (2023/08/10)
+
+* Add support for a page specific `toc_depth` setting.
+
 ## Version 0.4 (2020/04/09)
 
 * Account for code tags in codehilite output.

--- a/nature/base.html
+++ b/nature/base.html
@@ -57,13 +57,13 @@
     </div>
 {%- endmacro %}
 
-{%- macro toc_item(item) %}
+{%- macro toc_item(item, depth=6) %}
     <li>
         <a class="reference internal" href="{{ item.url }}">{{ item.title }}</a>
-        {%- if item.children %}
+        {%- if item.level < depth and item.children %}
         <ul>
         {%- for child in item.children %}
-            {{ toc_item(child) }}
+            {{ toc_item(child, depth) }}
         {%- endfor %}
         </ul>
         {%- endif %}
@@ -82,10 +82,11 @@
             {%- endblock %}
 
             {%- if page and page.toc %}
+            {%- set toc_depth = page.meta.toc_depth|int() if page.meta.toc_depth is defined else 6 %}
             <h3><a href="index.html">Table Of Contents</a></h3>
             <ul>
             {%- for item in page.toc %}
-                {{ toc_item(item) }}
+                {{ toc_item(item, toc_depth) }}
             {%- endfor %}
             </ul>
             {%- endif %}


### PR DESCRIPTION
This permits the number of levels of the toc to be reduced in some specific pages.