### PR TITLE
Strip tags from page title

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 0.6 (2023/09/13)
+
+* Strip tags from page title.
+
 ## Version 0.5 (2023/08/10)
 
 * Add support for a page specific `toc_depth` setting.

--- a/nature/base.html
+++ b/nature/base.html
@@ -151,7 +151,7 @@
       {%- endblock %}
 
       {%- block htmltitle %}
-        <title>{% if page and page.title %}{{ page.title }} &#8212; {% endif %}{{ config.site_name }} {{ config.theme.release }} documentation</title>
+        <title>{% if page and page.title %}{{ page.title|striptags }} &#8212; {% endif %}{{ config.site_name }} {{ config.theme.release }} documentation</title>
       {%- endblock %}
 
       {%- block styles %}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.5'
+VERSION = '0.6'
 
 with open('README.rst', mode='r') as fd:
     long_description = fd.read()


### PR DESCRIPTION
There shouldn't be any HTML tags in an HTML `<title>` so there is no harm in stripping them. And we get the benefit of not having the tags rendered in the browser's title bar/tab. See this [comment](https://github.com/Python-Markdown/markdown/pull/1379#pullrequestreview-1624460901) in Python-Markdown/markdown#1379.